### PR TITLE
fix: remove unsupported build config from wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,5 +2,4 @@ name = "rnalytics"
 compatibility_date = "2024-11-17"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".vercel/output/static"
-[build]
 command = "npm install && npm run pages:build"


### PR DESCRIPTION
- Remove [build] section as it's not supported in Cloudflare Pages
- Build commands should be configured in Pages dashboard instead